### PR TITLE
Refatorações

### DIFF
--- a/src/main/java/com/abacatepay/AbacatePay.java
+++ b/src/main/java/com/abacatepay/AbacatePay.java
@@ -8,34 +8,20 @@ import com.abacatepay.model.billing.CreateBillingData;
 import com.abacatepay.model.billing.CreateBillingResponse;
 import com.abacatepay.model.billing.ListBillingResponse;
 import feign.FeignException;
-import feign.RequestInterceptor;
 
 public class AbacatePay implements IAbacatePay {
 
     private static final String API_BASE_URL = "https://api.abacatepay.com/v1";
-
     private final AbacatePayClient client;
-    private final String apiKey;
-    private final String userAgent;
 
     public AbacatePay(String apiKey) {
-        this.apiKey = apiKey;
-        this.client = AbacatePayClientFactory.create(API_BASE_URL, requestInterceptor());
+        if (apiKey == null || apiKey.isEmpty()) {
+            throw new IllegalArgumentException("API key not provided");
+        }
 
         //TODO: Pegar a versão do SDK dinamicamente
-        this.userAgent = "Java SDK (1.0.0)";
-    }
-
-    private RequestInterceptor requestInterceptor() {
-        return template -> {
-            if (apiKey == null || apiKey.isEmpty()) {
-                throw new IllegalArgumentException("API key not provided");
-            }
-
-            template.header("Authorization", "Bearer " + apiKey);
-            template.header("Content-Type", "application/json");
-            template.header("User-Agent", userAgent);
-        };
+        String userAgent = "Java SDK (1.0.0)";
+        this.client = AbacatePayClientFactory.create(API_BASE_URL, apiKey, userAgent);
     }
 
     @Override

--- a/src/main/java/com/abacatepay/AbacatePay.java
+++ b/src/main/java/com/abacatepay/AbacatePay.java
@@ -32,7 +32,7 @@ public class AbacatePay implements IAbacatePay {
             @Override
             public CreateBillingResponse create(CreateBillingData data) {
                 try {
-                    return client.create(data);
+                    return client.createBilling(data);
                 } catch (IllegalArgumentException | FeignException e) {
                     return new CreateBillingResponse(e.getMessage());
                 }
@@ -41,7 +41,7 @@ public class AbacatePay implements IAbacatePay {
             @Override
             public ListBillingResponse list() {
                 try {
-                    return client.list();
+                    return client.listBillings();
                 } catch (IllegalArgumentException | FeignException e) {
                     return new ListBillingResponse(e.getMessage());
                 }

--- a/src/main/java/com/abacatepay/clients/AbacatePayClient.java
+++ b/src/main/java/com/abacatepay/clients/AbacatePayClient.java
@@ -8,8 +8,8 @@ import feign.RequestLine;
 public interface AbacatePayClient {
 
     @RequestLine("GET /billing/list")
-    ListBillingResponse list();
+    ListBillingResponse listBillings();
 
     @RequestLine("POST /billing/create")
-    CreateBillingResponse create(CreateBillingData body);
+    CreateBillingResponse createBilling(CreateBillingData body);
 }

--- a/src/main/java/com/abacatepay/clients/factories/AbacatePayClientFactory.java
+++ b/src/main/java/com/abacatepay/clients/factories/AbacatePayClientFactory.java
@@ -13,16 +13,26 @@ public class AbacatePayClientFactory {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    public static AbacatePayClient create(
-            String baseUrl, RequestInterceptor requestInterceptor
-    ) {
+    static {
         MAPPER.registerModule(new JavaTimeModule());
+    }
 
+    public static AbacatePayClient create(
+            String baseUrl, String apiKey, String userAgent
+    ) {
         return Feign.builder()
                 .decoder(new JacksonDecoder(MAPPER))
                 .encoder(new JacksonEncoder(MAPPER))
                 .errorDecoder(new CustomExceptionDecoder())
-                .requestInterceptor(requestInterceptor)
+                .requestInterceptor(requestInterceptor(apiKey, userAgent))
                 .target(AbacatePayClient.class, baseUrl);
+    }
+
+    private static RequestInterceptor requestInterceptor(String apiKey, String userAgent) {
+        return template -> {
+            template.header("Authorization", "Bearer " + apiKey);
+            template.header("Content-Type", "application/json");
+            template.header("User-Agent", userAgent);
+        };
     }
 }

--- a/src/main/java/com/abacatepay/model/billing/Billing.java
+++ b/src/main/java/com/abacatepay/model/billing/Billing.java
@@ -1,10 +1,12 @@
 package com.abacatepay.model.billing;
 
+import com.abacatepay.utils.DateUtils;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -20,16 +22,10 @@ public class Billing {
     private List<Product> products;
     private BillingKind frequency;
 
-    @JsonFormat(timezone = "America/Sao_Paulo", pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonFormat(timezone = DateUtils.DATE_TIMEZONE_DEFAULT, pattern = DateUtils.DATE_FORMAT_PATTERN)
     private LocalDateTime nextBilling;
 
     private Customer customer;
-
-    @JsonFormat(timezone = "America/Sao_Paulo", pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime createdAt;
-
-    @JsonFormat(timezone = "America/Sao_Paulo", pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private LocalDateTime updatedAt;
 }
 
 @Data

--- a/src/main/java/com/abacatepay/model/billing/CreateBillingResponse.java
+++ b/src/main/java/com/abacatepay/model/billing/CreateBillingResponse.java
@@ -1,18 +1,13 @@
 package com.abacatepay.model.billing;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 public class CreateBillingResponse {
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String error;
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Billing billing;
+    private Billing data;
 
     public CreateBillingResponse(String error) {
         this.error = error;

--- a/src/main/java/com/abacatepay/model/billing/ListBillingResponse.java
+++ b/src/main/java/com/abacatepay/model/billing/ListBillingResponse.java
@@ -1,6 +1,5 @@
 package com.abacatepay.model.billing;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -9,11 +8,8 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 public class ListBillingResponse {
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String error;
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private List<Billing> billings;
+    private List<Billing> data;
 
     public ListBillingResponse(String error) {
         this.error = error;

--- a/src/main/java/com/abacatepay/utils/DateUtils.java
+++ b/src/main/java/com/abacatepay/utils/DateUtils.java
@@ -1,0 +1,6 @@
+package com.abacatepay.utils;
+
+public class DateUtils {
+    public static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    public static final String DATE_TIMEZONE_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+}

--- a/src/test/java/com/abacatepay/AbacatePayTest.java
+++ b/src/test/java/com/abacatepay/AbacatePayTest.java
@@ -7,7 +7,6 @@ import com.abacatepay.model.billing.ListBillingResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -40,10 +39,10 @@ class AbacatePayTest {
         CreateBillingData data = CreateBillingData.builder().build();
         CreateBillingResponse expectedResponse = new CreateBillingResponse();
 
-        when(abacatePayClient.create(data)).thenReturn(expectedResponse);
+        when(abacatePayClient.createBilling(data)).thenReturn(expectedResponse);
 
         CreateBillingResponse result = abacatePay.billing().create(data);
-        verify(abacatePayClient, atMostOnce()).create(data);
+        verify(abacatePayClient, atMostOnce()).createBilling(data);
         Assertions.assertEquals(expectedResponse, result, "Should return the expected response");
     }
 
@@ -52,10 +51,10 @@ class AbacatePayTest {
         CreateBillingData data = CreateBillingData.builder().build();
         CreateBillingResponse expectedResponse = new CreateBillingResponse("API key not provided");
 
-        when(abacatePayClient.create(data)).thenThrow(new IllegalArgumentException("API key not provided"));
+        when(abacatePayClient.createBilling(data)).thenThrow(new IllegalArgumentException("API key not provided"));
 
         CreateBillingResponse result = abacatePay.billing().create(data);
-        verify(abacatePayClient, atMostOnce()).create(data);
+        verify(abacatePayClient, atMostOnce()).createBilling(data);
         Assertions.assertEquals(expectedResponse, result, "Should return the expected response");
     }
 
@@ -63,10 +62,10 @@ class AbacatePayTest {
     void shouldReturnBillingListResponseOnSucess() {
         ListBillingResponse expectedResponse = new ListBillingResponse();
 
-        when(abacatePayClient.list()).thenReturn(expectedResponse);
+        when(abacatePayClient.listBillings()).thenReturn(expectedResponse);
 
         ListBillingResponse result = abacatePay.billing().list();
-        verify(abacatePayClient, atMostOnce()).list();
+        verify(abacatePayClient, atMostOnce()).listBillings();
         Assertions.assertEquals(expectedResponse, result, "Should return the expected response");
     }
 
@@ -74,10 +73,10 @@ class AbacatePayTest {
     void shouldListBillingThrowsAnException() {
         ListBillingResponse expectedResponse = new ListBillingResponse("API key not provided");
 
-        when(abacatePayClient.list()).thenThrow(new IllegalArgumentException("API key not provided"));
+        when(abacatePayClient.listBillings()).thenThrow(new IllegalArgumentException("API key not provided"));
 
         ListBillingResponse result = abacatePay.billing().list();
-        verify(abacatePayClient, atMostOnce()).list();
+        verify(abacatePayClient, atMostOnce()).listBillings();
         Assertions.assertEquals(expectedResponse, result, "Should return the expected response");
     }
 

--- a/src/test/java/com/abacatepay/AbacatePayTest.java
+++ b/src/test/java/com/abacatepay/AbacatePayTest.java
@@ -19,8 +19,6 @@ class AbacatePayTest {
 
     @Mock
     private AbacatePayClient abacatePayClient;
-
-    @InjectMocks
     private AbacatePay abacatePay;
 
     @BeforeEach
@@ -81,5 +79,19 @@ class AbacatePayTest {
         ListBillingResponse result = abacatePay.billing().list();
         verify(abacatePayClient, atMostOnce()).list();
         Assertions.assertEquals(expectedResponse, result, "Should return the expected response");
+    }
+
+    @Test
+    void shouldThrowsIllegalArgumentExceptionIfApiKeyIsNull() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            abacatePay = new AbacatePay(null);
+        }, "Should throw an IllegalArgumentException");
+    }
+
+    @Test
+    void shouldThrowsIllegalArgumentExceptionIfApiKeyIsBlank() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            abacatePay = new AbacatePay("");
+        }, "Should throw an IllegalArgumentException");
     }
 }

--- a/src/test/java/com/abacatepay/model/billing/CreateBillingResponseTest.java
+++ b/src/test/java/com/abacatepay/model/billing/CreateBillingResponseTest.java
@@ -15,9 +15,9 @@ class CreateBillingResponseTest {
     void testGettersAndSetters() {
         CreateBillingResponse response = new CreateBillingResponse();
         response.setError("Error occurred");
-        response.setBilling(null);
+        response.setData(null);
 
         assertEquals("Error occurred", response.getError(), "Error field must be set correctly");
-        assertNull(response.getBilling(), "Billing field must be set correctly");
+        assertNull(response.getData(), "Billing field must be set correctly");
     }
 }

--- a/src/test/java/com/abacatepay/model/billing/ListBillingResponseTest.java
+++ b/src/test/java/com/abacatepay/model/billing/ListBillingResponseTest.java
@@ -15,9 +15,9 @@ class ListBillingResponseTest {
     void testGettersAndSetters() {
         ListBillingResponse response = new ListBillingResponse();
         response.setError("Error occurred");
-        response.setBillings(null);
+        response.setData(null);
 
         assertEquals("Error occurred", response.getError(), "Error field must be set correctly");
-        assertNull(response.getBillings(), "Billings field must be set correctly");
+        assertNull(response.getData(), "Billings field must be set correctly");
     }
 }


### PR DESCRIPTION
Esta pull request inclui várias alterações no SDK Java `AbacatePay` para aprimorar sua funcionalidade e melhorar a manutenção do código. As alterações envolvem a refatoração do processo de criação do cliente, a atualização de nomes de métodos para maior clareza e a modificação de estruturas de dados de resposta. Além disso, novas classes de utilitários e casos de teste foram adicionados para garantir robustez.

### Criação e refatoração do cliente:
* [`src/main/java/com/abacatepay/AbacatePay.java`](diffhunk://#diff-1c47b6253382f4816b3f189bc4e4c54a9093de28b9fe5fa919b86b8ecf6add4eL11-R24): Refatorou o processo de criação do cliente para incluir `apiKey` e `userAgent` diretamente no método `AbacatePayClientFactory.create`, removendo a necessidade de um `RequestInterceptor` separado.
* [`src/main/java/com/abacatepay/clients/factories/AbacatePayClientFactory.java`](diffhunk://#diff-af0386edcc52b2dee67d6ef82ff2cbc69788c75d7b13eb7c475591cdddbd9b34L16-R37): O método `create` foi atualizado para aceitar os parâmetros `apiKey` e `userAgent` e a lógica `RequestInterceptor` foi movida para um método privado.

### Atualizações de nomes de métodos:
* [`src/main/java/com/abacatepay/AbacatePay.java`](diffhunk://#diff-1c47b6253382f4816b3f189bc4e4c54a9093de28b9fe5fa919b86b8ecf6add4eL49-R35): `client.create` foi renomeado para `client.createBilling` e `client.list` para `client.listBillings` para maior clareza. [[1]](diffhunk://#diff-1c47b6253382f4816b3f189bc4e4c54a9093de28b9fe5fa919b86b8ecf6add4eL49-R35) [[2]](diffhunk://#diff-1c47b6253382f4816b3f189bc4e4c54a9093de28b9fe5fa919b86b8ecf6add4eL58-R44)
* [`src/main/java/com/abacatepay/clients/AbacatePayClient.java`](diffhunk://#diff-72093974866825e06637dbea3ae8159dc6059134ef2cbc5533021f26ac435d02L11-R14): Nomes de métodos atualizados para `createBilling` e `listBillings` na interface do cliente para corresponder às alterações na classe principal.

### Alterações na estrutura de dados de resposta:
* [`src/main/java/com/abacatepay/model/billing/CreateBillingResponse.java`](diffhunk://#diff-77ccbc2b2ddef16e8be9d21cd1725df9d1e232c71543a93f429a020e77b0a250L3-R10): O campo `billing` foi substituído por `data` para padronizar as estruturas de resposta.
* [`src/main/java/com/abacatepay/model/billing/ListBillingResponse.java`](diffhunk://#diff-7132e5c2000b94904f3cf6398de2c743a0b3b8098e8847d2938c1aa24b065acdL12-R12): Substituiu o campo `billings` por `data` para padronizar estruturas de resposta.

### Adições de utilitários e testes:
* [`src/main/java/com/abacatepay/utils/DateUtils.java`](diffhunk://#diff-ceb8470a9492e92a192fdd03590d01bea3f2a2a0f011f59bcc3b0b779bcc1500R1-R6): Adicionada uma nova classe de utilitário para constantes de formatação de data.
* [`src/test/java/com/abacatepay/AbacatePayTest.java`](diffhunk://#diff-bc14d58d8713970db51f4130972b9dbf74e434a7ac52f95b42ade8ee682b547fL45-R45): Adicionados novos casos de teste para verificar se uma `IllegalArgumentException` é lançada quando `apiKey` é nula ou em branco, e atualizados os casos de teste existentes para refletir as alterações no nome do método. [[1]](diffhunk://#diff-bc14d58d8713970db51f4130972b9dbf74e434a7ac52f95b42ade8ee682b547fL45-R45) [[2]](diffhunk://#diff-bc14d58d8713970db51f4130972b9dbf74e434a7ac52f95b42ade8ee682b547fL57-R95)

Essas mudanças melhoram coletivamente a clareza, a manutenibilidade e a robustez do SDK `AbacatePay`.